### PR TITLE
PTRN-30 Compare LockFreeHashTable with ThreadSafeMap

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,102 @@
+---
+Language: Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: false
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit: 100
+CommentPragmas: "^ IWYU pragma: ^\\.+"
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - forever # avoids { wrapped to next line
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex: "^<Q.*"
+    Priority: 200
+IncludeIsMainRegex: "(Test)?$"
+IndentCaseLabels: false
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+# Do not add QT_BEGIN_NAMESPACE/QT_END_NAMESPACE as this will indent lines in between.
+MacroBlockBegin: ""
+MacroBlockEnd: ""
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 150
+PenaltyBreakBeforeFirstCallParameter: 300
+PenaltyBreakComment: 500
+PenaltyBreakFirstLessLess: 400
+PenaltyBreakString: 600
+PenaltyExcessCharacter: 50
+PenaltyReturnTypeOnItsOwnLine: 300
+PointerAlignment: Right
+ReflowComments: false
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+TabWidth: 4
+UseTab: Never

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## System dependencies
 
-* Ubuntu 14.04 or above
+* Ubuntu 18.04 or above
 * Cmake 3.5.1 or above
-* gcc for C++11 5.4.0 or above.
+* gcc for C++11 5.4.0 or above
 
 ## Installation
 
@@ -23,6 +23,7 @@ cmake ..
 make
 sudo make install
 ```
+
 ## Run benchmarks
 
 Benchmarks can be run by the following command:
@@ -38,9 +39,9 @@ Each benchmark measures the cpu impact of *put*, *get* and *erase* method implem
 
 ## Method definition
 The measured methods are defined as follows:
-    * put: the insertion of an element inside a collection.
-    * get: the access to an element in a collection.
-    * erase: the deletion of an element in a collection.
+* put: the insertion of an element inside a collection.
+* get: the access to an element in a collection.
+* erase: the deletion of an element in a collection.
 
 ## Method correspondence for each class
 ### std::map
@@ -114,7 +115,7 @@ To better observe the benefits of using *LockFreeHashTable* an extensive benchma
 |  7 | std::string, int | SortedMap       | Remove      |        30 | 4.11676e+07 |           18 |
 |  8 | std::string, int | SortedMap       | Remove      |        40 | 4.04318e+07 |           17 |
 |  9 | std::string, int | SortedMap       | Remove      |        50 | 4.12092e+07 |           17 |
-| 10 | std::string, int | UnorderedMap    | Remove      |        10 | 1.5592e+07  |           45 |
+| 10 | std::string, int | UnorderedMap    | Remove      |        10 |  1.5592e+07 |           45 |
 | 11 | std::string, int | UnorderedMap    | Remove      |        20 | 1.78234e+07 |           41 |
 | 12 | std::string, int | UnorderedMap    | Remove      |        30 | 1.69932e+07 |           43 |
 | 13 | std::string, int | UnorderedMap    | Remove      |        40 | 1.77668e+07 |           39 |

--- a/modules/include/thread_safe_map.h
+++ b/modules/include/thread_safe_map.h
@@ -1,0 +1,38 @@
+#ifndef KPE_GPU_STREAMING_THREAD_SAFE_MAP_H
+#define KPE_GPU_STREAMING_THREAD_SAFE_MAP_H
+
+#include <mutex>
+#include <map>
+
+template<class K, class V>
+class ThreadSafeMap {
+public:
+    ThreadSafeMap()
+            : _map(), _mutex() {}
+
+    V &getValue(const K &key) {
+        std::lock_guard<std::mutex> guard(_mutex);
+        return _map.at(key);
+    }
+
+    void insert(const K &key, V &value) {
+        std::lock_guard<std::mutex> guard(_mutex);
+        _map.insert(std::make_pair(key, value));
+    }
+
+    void erase(const K &key) {
+        std::lock_guard<std::mutex> guard(_mutex);
+        _map.erase(key);
+    }
+
+    size_t getSize() {
+        std::lock_guard<std::mutex> guard(_mutex);
+        return _map.size();
+    }
+
+private:
+    std::map<K, V> _map;
+    std::mutex _mutex;
+};
+
+#endif //KPE_GPU_STREAMING_THREAD_SAFE_MAP_H


### PR DESCRIPTION
[PTRN-30]

### Tentative TODO
1. Replace [kpe-gpu-streaming](https://github.com/klepsydra-technologies/kpe-gpu-streaming/blob/KH-18-Klepsydra-AI-for-GPU-API-2/modules/gpu_streaming/include/klepsydra/gpu_streaming/thread_safe_map.h)'s `ThreadSafeMap` with `LockfreeHashTable`
2. Add Intel’s `concurrent_hash_map` to the game. ([oneTBB](https://github.com/oneapi-src/oneTBB) parallelism project.) -> memory intensive
3. Add Google's `tcmalloc` to the game. -> lightweight, will be tested in the future
4. Account memory usage, not just CPU.

[PTRN-30]: https://klepsydra.atlassian.net/browse/PTRN-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ